### PR TITLE
Add location prefix for HTTP cache purge requests

### DIFF
--- a/bundle/Cache/SwitchableHttpCachePurger.php
+++ b/bundle/Cache/SwitchableHttpCachePurger.php
@@ -7,6 +7,7 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
+use Ibexa\Contracts\HttpCache\Handler\ContentTagInterface;
 
 /**
  * A PurgeClient decorator that allows the actual purger to be switched on/off.
@@ -30,6 +31,15 @@ class SwitchableHttpCachePurger implements PurgeClientInterface
         if ($this->isSwitchedOff()) {
             return;
         }
+
+        // Add the appropiate cache tag prefix for locations
+        $locationIds = array_map(
+            static function ($locationId) {
+                $locationId = is_numeric($locationId) ? ContentTagInterface::LOCATION_PREFIX . $locationId : $locationId;
+                return $locationId;
+            },
+            $locationIds
+        );
 
         $this->purgeClient->purge($locationIds);
     }


### PR DESCRIPTION
Varnish cache purging is not working on content updates.

ezpublish_legacy/kernel/classes/ezcontentcachemanager.php (https://github.com/netgen/ezpublish-legacy/blob/ibexa4/kernel/classes/ezcontentcachemanager.php#L773) triggers the content/cache event and notifies any listeners with an array of location IDs.

vendor/netgen/ibexa-legacy-bridge/bundle/LegacyMapper/Configuration.php (https://github.com/netgen/ibexa-legacy-bridge/blob/3.x/bundle/LegacyMapper/Configuration.php#L207) assigns some listeners on the content/cache event, including...

vendor/netgen/ibexa-legacy-bridge/bundle/Cache/SwitchableHttpCachePurger.php (https://github.com/netgen/ibexa-legacy-bridge/blob/3.x/bundle/Cache/SwitchableHttpCachePurger.php) takes the location IDs and calls... 

vendor/ibexa/http-cache/src/lib/PurgeClient/RepositoryPrefixDecorator.php (https://github.com/ibexa/http-cache/blob/main/src/lib/PurgeClient/RepositoryPrefixDecorator.php#L31) but this does not add the cache tag prefix.

Previously, the equivalent "prefix decorator" added this prefix; but it was taken out here (or some equivalent commit in another branch when the prefix was shortened to "l"): https://github.com/ezsystems/ezplatform-http-cache/commit/0fc83ddc5dfc6c23babe02f2b82d7b7bf7cc0519#diff-63c7233cbea936cb4ad4aa95e8f0a6284c6d2e8cb20ad020230162df157bf1e5L42