### PR TITLE
Execute HTTP cache clear on ezjscore calls such as node priority updates

### DIFF
--- a/bundle/Cache/SwitchableHttpCachePurger.php
+++ b/bundle/Cache/SwitchableHttpCachePurger.php
@@ -8,6 +8,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
 use Ibexa\Contracts\HttpCache\Handler\ContentTagInterface;
+use FOS\HttpCacheBundle\CacheManager;
 
 /**
  * A PurgeClient decorator that allows the actual purger to be switched on/off.
@@ -21,9 +22,17 @@ class SwitchableHttpCachePurger implements PurgeClientInterface
      */
     private $purgeClient;
 
-    public function __construct(PurgeClientInterface $purgeClient)
+    public function __construct(PurgeClientInterface $purgeClient, CacheManager $cacheManager)
     {
         $this->purgeClient = $purgeClient;
+        $this->cacheManager = $cacheManager;
+    }
+
+    // FOSHttpCacheBundle has a listener on the kernel.terminate event that issues a flush() call
+    // However, legacy Ajax requests through ezjscore terminate execution before this event.
+    public function __destruct()
+    {
+        $this->cacheManager->flush();
     }
 
     public function purge(array $locationIds): void

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -228,7 +228,7 @@ services:
     ezpublish_legacy.switchable_http_cache_purger:
         class: eZ\Bundle\EzPublishLegacyBundle\Cache\SwitchableHttpCachePurger
         public: false
-        arguments: ["@ibexa.http_cache.purge_client"]
+        arguments: ["@ibexa.http_cache.purge_client", "@fos_http_cache.cache_manager"]
 
     ezpublish_legacy.content_exception_handler:
         class: eZ\Publish\Core\MVC\Legacy\EventListener\APIContentExceptionListener


### PR DESCRIPTION
Updating the priority of nodes in the legacy Administration Interface does not trigger the Varnish purge calls.

This is because node priority updates go through ezjscore, which terminates execution before a kernel.terminate event in FOSHttpCacheBundle issues a cache manager flush() call.

This was fixed years ago: https://issues.ibexa.co/browse/EZP-24755

The equivalent fix should probably go in:
https://github.com/ibexa/http-cache/blob/main/src/lib/PurgeClient/VarnishPurgeClient.php

... but the Ibexa code no longer cares about legacy bridge issues.

So this seems like the most appropriate place for the fix in the legacy bridge bundle.
