### PR TITLE
update hasParameter for getParameter to properly get the dfs_database…

### DIFF
--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -308,7 +308,7 @@ class Configuration implements EventSubscriberInterface
     {
         $clusterSettings = [];
         if ($this->container->hasParameter('dfs_database_url')) {
-            $databaseSettings = parse_url($this->container->hasParameter('dfs_database_url'));
+            $databaseSettings = parse_url($this->container->getParameter('dfs_database_url'));
             $clusterSettings += [
                 'file.ini/ClusteringSettings/FileHandler' => 'eZDFSFileHandler',
                 'file.ini/eZDFSClusteringSettings/MountPointPath' => $this->container->getParameter('dfs_nfs_path'),


### PR DESCRIPTION
…_url values

Hi @emodric ,

While working on a new bridge installation that uses DFS clustering I have noticed the following error
`In Configuration.php line 315:
  Notice: Undefined index: host`

It looks like after the first hasParameter check we never got to get the parameter itself.

Changing hasParameter to getParameter fixed the issue.

Let me know if you have any questions.

Thanks!
