### PR TITLE
Use urldecode for injected cluster DB password

### DIFF
--- a/bundle/LegacyMapper/Configuration.php
+++ b/bundle/LegacyMapper/Configuration.php
@@ -316,7 +316,7 @@ class Configuration implements EventSubscriberInterface
                 'file.ini/eZDFSClusteringSettings/DBPort' => $databaseSettings['port'] ?? 3306,
                 'file.ini/eZDFSClusteringSettings/DBName' => ltrim($databaseSettings['path'], '/'),
                 'file.ini/eZDFSClusteringSettings/DBUser' => $databaseSettings['user'] ?? '',
-                'file.ini/eZDFSClusteringSettings/DBPassword' => $databaseSettings['pass'] ?? '',
+                'file.ini/eZDFSClusteringSettings/DBPassword' => urldecode($databaseSettings['pass']) ?? '',
             ];
         }
 


### PR DESCRIPTION
The Ibexa code requires you to URL-encode database passwords (see https://doc.ibexa.co/en/latest/getting_started/troubleshooting/#encoding-database-password). But the cluster password is injected to the legacy stack via the legacy bridge encoded. We should URL-decode the password when it's sent to legacy.